### PR TITLE
Fix display messages in feed page

### DIFF
--- a/src/main/webapp/feed.html
+++ b/src/main/webapp/feed.html
@@ -7,6 +7,9 @@
     <link href="https://fonts.googleapis.com/css?family=Crete+Round|Playfair+Display|Satisfy" rel="stylesheet">
     <script src="/js/feed-loader.js"></script>
     <script src="/js/navigation-loader.js"></script>
+    <link rel="icon" href="images/doge.jpg">
+    <script src="https://cdn.jsdelivr.net/npm/showdown@1.9.0/dist/showdown.min.js"></script>
+    <script src="https://cdn.ckeditor.com/ckeditor5/11.2.0/classic/ckeditor.js"></script>
   </head>
 
   <body onload="buildUI()">

--- a/src/main/webapp/js/feed-loader.js
+++ b/src/main/webapp/js/feed-loader.js
@@ -39,7 +39,7 @@ function buildMessageDiv(message) {
 
   const bodyDiv = document.createElement('div');
   bodyDiv.classList.add('message-body');
-  bodyDiv.appendChild(document.createTextNode(message.text));
+  bodyDiv.innerHTML = convertInput(message.text);
 
   const messageDiv = document.createElement('div');
   messageDiv.classList.add("message-div");
@@ -47,6 +47,17 @@ function buildMessageDiv(message) {
   messageDiv.appendChild(bodyDiv);
 
   return messageDiv;
+}
+
+/**
+ * Converts user input with showdown markdown library.
+ * @param {String} input
+ * @return {Element}
+ */
+function convertInput(input) {
+  let converter = new showdown.Converter(),
+  html = converter.makeHtml(input);
+  return html
 }
 
 /** Fetches data and populates the UI of the page. */


### PR DESCRIPTION
Currently the /feed page does not display messages with style (showing raw html -- see attached image). Fix it to have the messages display properly.

![Screen Shot 2019-03-30 at 6 34 02 PM](https://user-images.githubusercontent.com/33410203/55283545-9248a400-531a-11e9-8e93-1263adc3a3e8.png)
